### PR TITLE
Add entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 RUN python3 -m pip install "poetry==${POETRY_VERSION}"
 COPY ./app ./app
 COPY ./alembic ./alembic
+COPY ./gunicorn.conf.py ./
+COPY ./scripts ./scripts
 COPY alembic.ini pyproject.toml .env ./
 RUN poetry config virtualenvs.create false && poetry install $INSTALL_ARGS

--- a/app/repositories/user.py
+++ b/app/repositories/user.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,14 @@
 version: '3.9'
 services:
+  cache:
+    container_name: backend_cache
+    image: redis:6.2.5-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - cache_data:/var/lib/redis/data
+    ports:
+      - '6379:6379'
+
   db:
     container_name: backend_db
     image: postgres:latest
@@ -43,3 +52,4 @@ services:
 
 volumes:
   postgres_data:
+  cache_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,10 @@ services:
     ports:
       - '5432:5432'
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=pg_pass
-      - POSTGRES_DB=backend
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: pg_pass
+      POSTGRES_DB: backend
+
   app:
     container_name: app
     build:
@@ -27,28 +28,34 @@ services:
       dockerfile: Dockerfile
       args:
         INSTALL_ARGS: "--no-root"
-    command: bash -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
+    entrypoint: scripts/entrypoint.sh
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     volumes:
-      - ./app:/app/app/:cached
-      - ./alembic:/app/alembic/:cached
+      - '.:/app:cached'
+      - './alembic:/app/alembic/:cached'
     ports:
       - '8000:8000'
     depends_on:
       - db
+      - cache
     env_file:
       - .env
     environment:
-      - 'POSTGRES_SERVER=db'
+      POSTGRES_SERVER: db
+      DATABASE_URL: "postgresql+asyncpg://postgres:pg_pass@backend_db/backend"
+      REDIS_URL: "redis://backend_cache"
+
   pgadmin:
     container_name: pgadmin
     image: dpage/pgadmin4
     environment:
-      - PGADMIN_DEFAULT_EMAIL=admin@star.lite
-      - PGADMIN_DEFAULT_PASSWORD=admin
+      PGADMIN_DEFAULT_EMAIL: admin@star.lite
+      PGADMIN_DEFAULT_PASSWORD: admin
     ports:
       - '5050:80'
     depends_on:
-      - db
+      - app
+
 
 volumes:
   postgres_data:

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -17,8 +17,7 @@ assert MIN_WORKERS > 0
 if web_concurrency := os.getenv('GUNICORN_WORKER_COUNT'):
     web_concurrency = max(int(web_concurrency), MIN_WORKERS)
 else:
-    # If there's no value set, let's infer (multiplier * cores)
-    # Gunicorn docs recommend ~2-4 * cores, while the Heroku docs seem to suggest 1-1.5x.
+    # If there's no value set, infer (multiplier * cores)
     web_concurrency = max(int(MULTIPLIER * cores), MIN_WORKERS)
 
 if MAX_WORKERS:

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,20 +1,19 @@
 import os
-
 import platform
 
-if platform.system() == 'Linux':
+if platform.system() == "Linux":
     # Only runnable on linux
     cores = len(os.sched_getaffinity(0))
 else:
     cores = os.cpu_count()
 
 MULTIPLIER = 2  # gunicorn recommends 2-4x cores
-MAX_WORKERS = os.getenv('MAX_WORKERS')
-MIN_WORKERS = os.getenv('MIN_WORKERS', 2)
+MAX_WORKERS = os.getenv("MAX_WORKERS")
+MIN_WORKERS = os.getenv("MIN_WORKERS", 2)
 assert MIN_WORKERS > 0
 
 # Set workers dynamically
-if web_concurrency := os.getenv('GUNICORN_WORKER_COUNT'):
+if web_concurrency := os.getenv("GUNICORN_WORKER_COUNT"):
     web_concurrency = max(int(web_concurrency), MIN_WORKERS)
 else:
     # If there's no value set, infer (multiplier * cores)
@@ -25,12 +24,12 @@ if MAX_WORKERS:
 
 # Gunicorn config variables
 workers = web_concurrency
-threads = os.getenv('GUNICORN_THREAD_COUNT', 2)
-bind = os.getenv('BIND', None) or f'{os.getenv("HOST", "0.0.0.0")}:{os.getenv("PORT", "80")}'
-loglevel = os.getenv('LOG_LEVEL', 'info')
-errorlog = os.getenv('ERROR_LOG', '-')  # '-' makes gunicorn log to stderr
-accesslog = os.getenv('ACCESS_LOG', None)
-worker_tmp_dir = '/dev/shm'
+threads = os.getenv("GUNICORN_THREAD_COUNT", 2)
+bind = os.getenv("BIND", None) or f'{os.getenv("HOST", "0.0.0.0")}:{os.getenv("PORT", "80")}'
+loglevel = os.getenv("LOG_LEVEL", "info")
+errorlog = os.getenv("ERROR_LOG", "-")  # '-' makes gunicorn log to stderr
+accesslog = os.getenv("ACCESS_LOG", None)
+worker_tmp_dir = "/dev/shm"
 preload_app = True
 keepalive = 5
 max_requests = 1000

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,40 @@
+import os
+
+import platform
+
+if platform.system() == 'Linux':
+    # Only runnable on linux
+    cores = len(os.sched_getaffinity(0))
+else:
+    cores = os.cpu_count()
+
+MULTIPLIER = 2  # gunicorn recommends 2-4x cores
+MAX_WORKERS = os.getenv('MAX_WORKERS')
+MIN_WORKERS = os.getenv('MIN_WORKERS', 2)
+assert MIN_WORKERS > 0
+
+# Set workers dynamically
+if web_concurrency := os.getenv('GUNICORN_WORKER_COUNT'):
+    web_concurrency = max(int(web_concurrency), MIN_WORKERS)
+else:
+    # If there's no value set, let's infer (multiplier * cores)
+    # Gunicorn docs recommend ~2-4 * cores, while the Heroku docs seem to suggest 1-1.5x.
+    web_concurrency = max(int(MULTIPLIER * cores), MIN_WORKERS)
+
+if MAX_WORKERS:
+    web_concurrency = min(web_concurrency, int(MAX_WORKERS))
+
+# Gunicorn config variables
+workers = web_concurrency
+threads = os.getenv('GUNICORN_THREAD_COUNT', 2)
+bind = os.getenv('BIND', None) or f'{os.getenv("HOST", "0.0.0.0")}:{os.getenv("PORT", "80")}'
+loglevel = os.getenv('LOG_LEVEL', 'info')
+errorlog = os.getenv('ERROR_LOG', '-')  # '-' makes gunicorn log to stderr
+accesslog = os.getenv('ACCESS_LOG', None)
+worker_tmp_dir = '/dev/shm'
+preload_app = True
+keepalive = 5
+max_requests = 1000
+max_request_jitter = 100
+graceful_timeout = 25
+timeout = 30

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,19 @@
 [[package]]
+name = "aioredis"
+version = "2.0.1"
+description = "asyncio (PEP 3156) Redis support"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+async-timeout = "*"
+typing-extensions = "*"
+
+[package.extras]
+hiredis = ["hiredis (>=1.0)"]
+
+[[package]]
 name = "alembic"
 version = "1.7.5"
 description = "A database migration tool for SQLAlchemy."
@@ -40,6 +55,14 @@ python-versions = ">=3.6"
 
 [package.extras]
 tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+
+[[package]]
+name = "async-timeout"
+version = "4.0.2"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "asyncpg"
@@ -171,6 +194,20 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
 docs = ["sphinx"]
+
+[[package]]
+name = "gunicorn"
+version = "20.1.0"
+description = "WSGI HTTP Server for UNIX"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
 
 [[package]]
 name = "h11"
@@ -571,9 +608,13 @@ standard = ["websockets (>=10.0)", "httptools (>=0.2.0,<0.4.0)", "watchgod (>=0.
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "f7d73ac7d9240538c4cf1a7cc72ef822cc21b551e6e62b044235f2d87438d037"
+content-hash = "3f23faa0d1512531079c0916af0a276d7d68df182820f7a6d5b1fe811a97b49a"
 
 [metadata.files]
+aioredis = [
+    {file = "aioredis-2.0.1-py3-none-any.whl", hash = "sha256:9ac0d0b3b485d293b8ca1987e6de8658d7dafcca1cddfcd1d506cae8cdebfdd6"},
+    {file = "aioredis-2.0.1.tar.gz", hash = "sha256:eaa51aaf993f2d71f54b70527c440437ba65340588afeb786cd87c55c89cd98e"},
+]
 alembic = [
     {file = "alembic-1.7.5-py3-none-any.whl", hash = "sha256:a9dde941534e3d7573d9644e8ea62a2953541e27bc1793e166f60b777ae098b4"},
     {file = "alembic-1.7.5.tar.gz", hash = "sha256:7c328694a2e68f03ee971e63c3bd885846470373a5b532cf2c9f1601c413b153"},
@@ -585,6 +626,10 @@ anyio = [
 asgiref = [
     {file = "asgiref-3.4.1-py3-none-any.whl", hash = "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"},
     {file = "asgiref-3.4.1.tar.gz", hash = "sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9"},
+]
+async-timeout = [
+    {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
+    {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
 ]
 asyncpg = [
     {file = "asyncpg-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bf5e3408a14a17d480f36ebaf0401a12ff6ae5457fdf45e4e2775c51cc9517d3"},
@@ -765,6 +810,10 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
+]
+gunicorn = [
+    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
 ]
 h11 = [
     {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ python-dotenv = "*"
 sqlalchemy = "*"
 starlite = "*"
 uvicorn = "*"
+aioredis = "^2.0.1"
+gunicorn = "^20.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Script run before gunicorn/arq is allowed to start
+# We make sure redis and postgres are ready, and we run migrations.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+redis_ready() {
+    python << END
+import asyncio
+import sys
+
+from aioredis import Redis
+
+
+async def c():
+    try:
+        redis = Redis.from_url("${REDIS_URL}", db=0)
+        await redis.ping()
+    except ConnectionError:
+        sys.exit(-1)
+
+
+if __name__ == '__main__':
+    asyncio.run(c())
+END
+}
+
+postgres_ready() {
+  python <<END
+import asyncio
+import sys
+from asyncpg import connect
+
+
+async def c():
+    database_url = "${DATABASE_URL}".replace('+asyncpg','')
+    try:
+        await connect(dsn=f"{database_url}")
+    except ConnectionRefusedError:
+        sys.exit(-1)
+
+if __name__ == '__main__':
+    asyncio.run(c())
+END
+}
+
+# Check Gunicorn config
+gunicorn --check-config --config=gunicorn.conf.py app.main:app
+echo "Gunicorn config OK"
+
+# Wait for Redis to be ready
+until redis_ready; do
+  >&2 echo "Waiting for Redis to become available..."
+  sleep 5
+done
+>&2 echo "Redis is available"
+
+# Wait for PostgreSQL to be ready
+until postgres_ready; do
+  echo >&2 "Waiting for PostgreSQL to become available..."
+  sleep 5
+done
+echo >&2 "PostgreSQL is available"
+
+# Run migrations
+alembic upgrade head
+
+exec "$@"


### PR DESCRIPTION
PR adds an `entrypoint.sh` where we can perform readiness checks and run migrations. The entrypoint can (and should) also be leveraged during deployments.

*Without* an explicit readiness check, we can end up in a situation (running docker compose), where the app initializes before postgres is actually ready. We can leverage [entrypoint](https://docs.docker.com/compose/compose-file/compose-file-v3/#entrypoint) to run a more robust readiness check before spinning up our app container. In other words, this fixes a container startup-timing issue; but it also gives us a better place to put our `alembic` commands and other startup-checks.

In addition to the entrypoint script, this PR adds a gunicorn config that can be used when deploying your application (deploy using`gunicorn app.main:app --config gunicorn.conf.py`), and adds a cache container.